### PR TITLE
Composed modules initialisation

### DIFF
--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -73,6 +73,27 @@
       "remoteCopyBuildOutput": false,
       "remoteCopySourcesMethod": "rsync",
       "addressSanitizerRuntimeFlags": "detect_leaks=0"
+    },
+    {
+      "name": "Ubuntu_FPGA",
+      "generator": "Ninja",
+      "configurationType": "Debug",
+      "cmakeExecutable": "cmake",
+      "remoteCopySourcesExclusionList": [ ".vs", ".git", "out" ],
+      "cmakeCommandArgs": "-DENABLE_TESTS=False -DENABLE_FPGA=True",
+      "buildCommandArgs": "",
+      "ctestCommandArgs": "",
+      "inheritEnvironments": [ "linux_arm" ],
+      "remoteMachineName": "1252585813;192.168.1.33 (username=root, port=22, authentication=Password)",
+      "remoteCMakeListsRoot": "$HOME/.vs/${projectDirName}/${workspaceHash}/src",
+      "remoteBuildRoot": "$HOME/.vs/${projectDirName}/${workspaceHash}/out/build/${name}",
+      "remoteInstallRoot": "$HOME/.vs/${projectDirName}/${workspaceHash}/out/install/${name}",
+      "remoteCopySources": true,
+      "rsyncCommandArgs": "-t --delete --delete-excluded",
+      "remoteCopyBuildOutput": false,
+      "remoteCopySourcesMethod": "rsync",
+      "remotePrebuildCommand": "rmmod u-dma-buf.ko",
+      "remotePostbuildCommand": "perl $HOME/.vs/${projectDirName}/${workspaceHash}/out/build/${name}/apps/setupUdma.pl"
     }
   ]
 }

--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -131,7 +131,26 @@ set(data
     ${OrkhestraFPGAStream_SOURCE_DIR}/resources/benchmark/slow_benchmark_config.ini
 
     ${OrkhestraFPGAStream_SOURCE_DIR}/resources/tables_data.json
-    ${OrkhestraFPGAStream_SOURCE_DIR}/resources/pr_hw_library.json)
+    ${OrkhestraFPGAStream_SOURCE_DIR}/resources/pr_hw_library.json
+    
+    #${OrkhestraFPGAStream_SOURCE_DIR}/resources/hardware/partial_Filter.bin
+    #${OrkhestraFPGAStream_SOURCE_DIR}/resources/hardware/partial_Filter.json
+    #${OrkhestraFPGAStream_SOURCE_DIR}/resources/hardware/partial_RTM_94.bin
+    #${OrkhestraFPGAStream_SOURCE_DIR}/resources/hardware/partial_RTM_94.json
+    #${OrkhestraFPGAStream_SOURCE_DIR}/resources/hardware/partial_TAA_64.bin
+    #${OrkhestraFPGAStream_SOURCE_DIR}/resources/hardware/partial_TAA_64.json
+    #${OrkhestraFPGAStream_SOURCE_DIR}/resources/hardware/partial_TAA_91.bin
+    #${OrkhestraFPGAStream_SOURCE_DIR}/resources/hardware/partial_TAA_91.json
+    #${OrkhestraFPGAStream_SOURCE_DIR}/resources/hardware/partial_TAA_94.bin
+    #${OrkhestraFPGAStream_SOURCE_DIR}/resources/hardware/partial_TAA_94.json
+    #${OrkhestraFPGAStream_SOURCE_DIR}/resources/hardware/static.bin
+    #${OrkhestraFPGAStream_SOURCE_DIR}/resources/hardware/static.json
+    #${OrkhestraFPGAStream_SOURCE_DIR}/resources/hardware/static_cheat.bin
+    #${OrkhestraFPGAStream_SOURCE_DIR}/resources/hardware/static_cheat.json
+    #${OrkhestraFPGAStream_SOURCE_DIR}/resources/hardware/staticwithILA.bin
+    #${OrkhestraFPGAStream_SOURCE_DIR}/resources/hardware/staticwithILA.json
+
+    ${OrkhestraFPGAStream_SOURCE_DIR}/extra_scripts/setupUdma.pl)
 
 add_executable (OrkhestraFPGAStream main.cpp ${data})
 

--- a/extra_scripts/setupUdma.pl
+++ b/extra_scripts/setupUdma.pl
@@ -1,0 +1,10 @@
+#!/usr/bin/perl
+# Setup this to run on startup
+
+use warnings;
+use strict;
+
+my $BUFSIZE=128 * 1024 * 1024;
+my $command="insmod /home/ubuntu/udmabuf/u-dma-buf.ko udmabuf0=$BUFSIZE udmabuf1=$BUFSIZE udmabuf2=$BUFSIZE udmabuf3=$BUFSIZE udmabuf4=$BUFSIZE udmabuf5=$BUFSIZE";
+
+exec ($command) or print STDERR "Couldn't exec script: $!";

--- a/src/fos/udma.cpp
+++ b/src/fos/udma.cpp
@@ -9,7 +9,7 @@
 #include <fcntl.h>
 #include <unistd.h>
 
-const std::string sysfsRoot = "/sys/class/udmabuf";
+const std::string sysfsRoot = "/sys/class/u-dma-buf";
 const std::string devfsRoot = "/dev";
 
 // reads hex or dec int from file


### PR DESCRIPTION
Changed the build target for a new Ubuntu image which uses an update u-dma-library to remove the buffers before building and initialise the buffers after building.

FYI - Incorrect branch name